### PR TITLE
Checkbox checkmarks that scale

### DIFF
--- a/src/htdocs/css/_form.scss
+++ b/src/htdocs/css/_form.scss
@@ -161,14 +161,14 @@ input[type='radio'] {
 input[type='checkbox']:checked + label:after {
   content: '';
   display: block;
-  border-bottom: 3px solid #fff;
-  border-right: 3px solid #fff;
-  width: 0.35rem;
-  height: 0.8rem;
+  border-bottom: 0.2em solid #fff;
+  border-right: 0.2em solid #fff;
+  width: 0.25em;
+  height: 0.6em;
   transform: rotate(45deg);
   position: absolute;
-  top: 0.6rem;
-  left: 1.6rem;
+  top: 0.24em;
+  left: 0.88em;
 }
 
 input[type='radio'] {

--- a/src/htdocs/form.php
+++ b/src/htdocs/form.php
@@ -68,6 +68,37 @@ if (!isset($TEMPLATE)) {
       </ul>
     </fieldset>
 
+    <fieldset class="usa-fieldset-inputs">
+      <legend>Different Size Checkboxes</legend>
+      <ul class="no-style">
+        <li>
+          <input type="checkbox" name="topping" id="topping-sprinkles"
+              value="sprinkles" checked="checked" />
+          <label for="topping-sprinkles" style="font-size:13px">Sprinkles</label>
+        </li>
+        <li>
+          <input type="checkbox" name="topping" id="topping-sprinkles1"
+              value="sprinkles" checked="checked" />
+          <label for="topping-sprinkles1" style="font-size:15px">Sprinkles</label>
+        </li>
+        <li>
+          <input type="checkbox" name="topping" id="topping-sprinkles2"
+              value="sprinkles" checked="checked" />
+          <label for="topping-sprinkles2">Sprinkles</label>
+        </li>
+        <li>
+          <input type="checkbox" name="topping" id="topping-sprinkles3"
+              value="sprinkles" checked="checked" />
+          <label for="topping-sprinkles3" style="font-size:22px">Sprinkles</label>
+        </li>
+        <li>
+          <input type="checkbox" name="topping" id="topping-sprinkles4"
+              value="sprinkles" checked="checked" />
+          <label for="topping-sprinkles4" style="font-size:32px">Sprinkles</label>
+        </li>
+      </ul>
+    </fieldset>
+
     <label>Now choose your container:
       <select>
         <option value="waffle-cone">Waffle Cone</option>


### PR DESCRIPTION
I have been implementing the new checkboxes and in lots of places the inputs are smaller than 1em. Based on how the checkmark is being added in an after, this provides a solution that works across browsers and different label font-sizes.

The markup looks ridiculous, however:
- It's more consistent across browsers
- scales up and down
- looks better in IE