### PR TITLE
Make cooperator logo as tall as USGS logo

### DIFF
--- a/src/htdocs/css/_banner.scss
+++ b/src/htdocs/css/_banner.scss
@@ -9,7 +9,7 @@
     height: 100%;
     left: 186px;
     overflow: hidden;
-    padding: calc($spacing * 3/2) 0;
+    padding: 1em 0;
     position: absolute;
     top: 0;
     white-space: nowrap;


### PR DESCRIPTION
`1em` is the same as USGS logo on large screens:
https://github.com/usgs/hazdev-template/compare/master...jmfee-usgs:cooperator-logo-size?expand=1#diff-04f76c2f3a81b784e7c9473eec278b34L71