### PR TITLE
Change how normal radio/checkbox inputs are hidden

### DIFF
--- a/src/htdocs/css/_form.scss
+++ b/src/htdocs/css/_form.scss
@@ -140,6 +140,7 @@ input[type='radio'] {
   opacity: 0;
   position: absolute;
   width: 0;
+  z-index: -1;
 
   + label {
     cursor: pointer;

--- a/src/htdocs/css/_form.scss
+++ b/src/htdocs/css/_form.scss
@@ -134,8 +134,12 @@ select {
 
 input[type='checkbox'],
 input[type='radio'] {
-  left: -999em;
+  display: block;
+  height: 0;
+  overflow: hidden;
+  opacity: 0;
   position: absolute;
+  width: 0;
 
   + label {
     cursor: pointer;


### PR DESCRIPTION
This changes how the inputs are hidden, which resolves the Chrome "scroll-jumping" issue we saw on the event pages.