### PR TITLE
Navigation update

### DIFF
--- a/src/htdocs/css/_footer.scss
+++ b/src/htdocs/css/_footer.scss
@@ -10,18 +10,18 @@
   }
 
   a {
-    color: $gray-text-color;
+      color: $text-color;
     display: block;
     padding: calc($spacing * 1/2) $spacing;
     text-decoration: none;
 
     &:visited {
-      color: $gray-text-color;
+      color: $text-color;
     }
 
     &:hover,
     &.selected {
-      text-decoration: underline;
+      background: $gray-lighter;
     }
   }
 
@@ -40,7 +40,7 @@
     }
 
     > a {
-      color: $gray-text-color;
+      color: $text-color;
       font-size: 0.88em;
       padding: calc($spacing * 2/3) calc($spacing * 1/0.88);
     }

--- a/src/htdocs/css/_footer.scss
+++ b/src/htdocs/css/_footer.scss
@@ -23,10 +23,8 @@
       text-decoration: underline;
     }
 
-    &:active,
-    &:hover,
     &.selected {
-      background: $gray-lighter;
+      font-style: italic;
     }
   }
 

--- a/src/htdocs/css/_footer.scss
+++ b/src/htdocs/css/_footer.scss
@@ -38,16 +38,16 @@
   }
 
   > section {
-    margin: $spacing 0;
+    margin: calc($spacing / 2) 0;
 
     > header {
-      margin: $spacing 0 calc($spacing / 2);
+      margin: calc($spacing / 2) 0 0;
     }
 
     > a {
       color: $gray-text-color;
       font-size: 0.88em;
-      padding: calc($spacing * 2/3) calc($spacing * 1.5);
+      padding: calc($spacing * 2/3) calc($spacing * 1/0.88);
     }
   }
 }

--- a/src/htdocs/css/_footer.scss
+++ b/src/htdocs/css/_footer.scss
@@ -1,99 +1,76 @@
-/* section nav */
+/* reset <a> tag styles */
 .site-sectionnav {
+  margin: $spacing 0;
 
-  /* Ungrouped Links */
-  > a {
-    background-color: $secondary-lighter;
-    background-image: none;
-    border-top: 1px solid $secondary;
-    color: $secondary-text-color;
+  > a + a,
+  > a + section,
+  > section + a,
+  > section + section {
+    border-top: 1px solid $gray;
+  }
+
+  a {
+    color: $gray-text-color;
     display: block;
-    padding: calc($spacing * 2/3) $spacing;
+    padding: calc($spacing * 1/2) $spacing;
     text-decoration: none;
-    transition: background .25s ease-out;
 
     &:visited {
-      color: $secondary-text-color;
+      color: $gray-text-color;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:active,
+    &:hover,
+    &.selected {
+      background: $gray-lighter;
     }
   }
 
-  > a:hover {
-    text-decoration: underline;
+  > a,
+  > a:visited,
+  > section > header > a,
+  > section > header > a:visited {
+    color: $text-color;
   }
 
-  /* Grouped Links */
   > section {
-    margin: 0 0 0.2em 0;
+    margin: $spacing 0;
 
-    /* items in a nav group */
-    > a,
     > header {
-      color: $secondary-text-color;
-      display: block;
-      padding: calc($spacing * 2/3) $spacing;
-      transition: background .25s ease-out;
+      margin: $spacing 0 calc($spacing / 2);
     }
 
-    /* indent group items */
     > a {
-      padding-left: calc(3/2 * $spacing);
-      /* for linear-gradient background */
-      position: relative;
-
-      /* gradient separator between section links */
-      &:before {
-        background-image: linear-gradient(to right, rgba(0, 0, 0, 0) 0,
-            rgba(0, 0, 0, 0.1) 2.5em, rgba(0, 0, 0, 0) 100%);
-        content: '';
-        height: 1px;
-        left: 0;
-        position: absolute;
-        top: 0;
-        width: 100%;
-      }
-    }
-
-    /* nav group header */
-    > header {
-      background-color: $secondary-lighter;
-      border-bottom: 1px solid $secondary;
-      border-top: 1px solid $secondary;
-      font-weight: normal;
-      text-shadow: 0 0 2px #fff;
-    }
-
-    > a,
-    > header > a {
-      background-image: none;
-      text-decoration: none;
-
-      /* hover styles for nav items */
-      &:hover {
-        background-color: $secondary-lighter;
-        text-decoration: underline;
-      }
-    }
-
-    > header > a {
-      display: block;
-      color: $secondary-text-color;
-
-      &:hover {
-        background-color: $secondary-lighter;
-      }
+      color: $gray-text-color;
+      font-size: 0.88em;
+      padding: calc($spacing * 2/3) calc($spacing * 1.5);
     }
   }
 }
+
+
+/* style the section navigation */
+.site-footer {
+  padding: $spacing;
+}
+
+/* ------------------------------------------------------------------------- */
+/* ------------------------------------------------------------------------- */
+/* ------------------------------------------------------------------------- */
 
 
 /* search form */
 
 .site-search {
   display: block;
-  margin: $spacing;
+  margin-top: $spacing;
   position: relative;
 
-  >[type="search"] {
+  > [type="search"] {
     appearance: none;
     display: block;
     margin: 0;
@@ -113,7 +90,6 @@
     margin: $spacing 0 0 0;
   }
 }
-
 
 /* site nav */
 
@@ -175,39 +151,11 @@
   }
 }
 
-
-@media screen and (min-width: $breakpoint-offcanvas) {
-
-  .site-footer {
-    padding: 0 $spacing;
-  }
-
-  .site-sectionnav,
-  .site-sitenav,
+@media screen and (max-width: $breakpoint-offcanvas) {
   .site-search {
-    margin: $spacing 0;
-  }
-
-  .site-sectionnav {
-
-    > a,
-    > strong {
-      border: 1px solid $secondary;
-      margin: 0 0 $spacing;
-    }
-
-    > section {
-      border: 1px solid $secondary;
-      margin: 0 0 $spacing;
-
-      header,
-      header > a {
-        border-top: 0;
-      }
-    }
+    padding: 0 1em;
   }
 }
-
 
 @media print {
   .site-sectionnav,

--- a/src/htdocs/css/_footer.scss
+++ b/src/htdocs/css/_footer.scss
@@ -10,18 +10,19 @@
   }
 
   a {
-      color: $text-color;
+    color: $gray-text-color;
     display: block;
     padding: calc($spacing * 1/2) $spacing;
     text-decoration: none;
 
     &:visited {
-      color: $text-color;
+      color: $gray-text-color;
     }
 
     &:hover,
     &.selected {
       background: $gray-lighter;
+      color: $text-color;
     }
   }
 

--- a/src/htdocs/css/_footer.scss
+++ b/src/htdocs/css/_footer.scss
@@ -26,6 +26,7 @@
     }
   }
 
+  /* top level is dark gray */
   > a,
   > a:visited,
   > section > header > a,
@@ -41,7 +42,6 @@
     }
 
     > a {
-      color: $text-color;
       font-size: 0.88em;
       padding: calc($spacing * 2/3) calc($spacing * 1/0.88);
     }

--- a/src/htdocs/css/_footer.scss
+++ b/src/htdocs/css/_footer.scss
@@ -19,12 +19,9 @@
       color: $gray-text-color;
     }
 
-    &:hover {
-      text-decoration: underline;
-    }
-
+    &:hover,
     &.selected {
-      font-style: italic;
+      text-decoration: underline;
     }
   }
 

--- a/src/htdocs/css/_variables.scss
+++ b/src/htdocs/css/_variables.scss
@@ -3,9 +3,10 @@
 
 $text-color: #333333 !default;
 
-$gray: #e0e0e0 !default;
+$gray: #ededed !default;
 $gray-lighter: #f4f4f4 !default;
 $gray-darker: #757575 !default;
+$gray-text-color: #888888 !default;
 
 $primary: #205493 !default;
 $primary-lighter: #0071bc !default;

--- a/src/htdocs/css/_variables.scss
+++ b/src/htdocs/css/_variables.scss
@@ -6,7 +6,7 @@ $text-color: #333333 !default;
 $gray: #ededed !default;
 $gray-lighter: #f4f4f4 !default;
 $gray-darker: #757575 !default;
-$gray-text-color: #888888 !default;
+$gray-text-color: #777777 !default;
 
 $primary: #205493 !default;
 $primary-lighter: #0071bc !default;

--- a/src/lib/functions.inc.php
+++ b/src/lib/functions.inc.php
@@ -96,7 +96,7 @@ function navItem ($href, $text, $isCurrentPage=null) {
 	}
 
 	if ($isCurrentPage) {
-		return '<a href="' . $href . '"><strong>' . $text . '</strong></a>';
+		return '<a class="selected" href="' . $href . '">' . $text . '</a>';
 	} else {
 		return '<a href="' . $href . '">' . $text . '</a>';
 	}


### PR DESCRIPTION
The idea for this change goes along with moving away from the "boxy" feel of our navigation. I'm trying to style away a lot of the borders and background colors in our navigation so that the content on our website is the user's main focus, and the navigation is secondary.

I've included some screenshots for discussion. I used the earthquake-eventpage app as the testing area for these changes. You can also see the back link has been styled, but that is part of another ticket (#249).

<img width="375" alt="screen shot 2016-06-22 at 8 52 33 am" src="https://cloud.githubusercontent.com/assets/1932750/16271504/81250e56-3857-11e6-8c75-1124301e93f4.png">
<img width="928" alt="screen shot 2016-06-22 at 8 52 51 am" src="https://cloud.githubusercontent.com/assets/1932750/16271503/812427f2-3857-11e6-8163-b7fad14d3ca4.png">
 