### PR TITLE
changed layout of featured items for homepage

### DIFF
--- a/src/htdocs/css/_features.scss
+++ b/src/htdocs/css/_features.scss
@@ -1,40 +1,15 @@
 .feature-main {
-  max-width: 464px;
 
   > a {
     display: block;
     position: relative;
     width: 100%;
 
-    > .feature-title {
-      color: #eee;
-      font-size: 1.1em;
-      left: 10%;
-      line-height: 1.3;
-      margin: 0;
-      position: absolute;
-      text-align: center;
-      text-shadow: -1px 1px 0px #000, -3px 3px 10px #666;
-      top: 20px;
-      width: 80%;
-      z-index: 2;
-    }
-
     > .feature-image {
       background-repeat: no-repeat;
       background-size: 100%;
       padding-bottom: 65%;
       width: 100%;
-
-      &:after {
-        background: linear-gradient(rgba(0, 0, 0, 0.5) 0%, rgba(0,0,0,0) 100%);
-        content: '';
-        display: block;
-        padding-bottom:50%;
-        position: absolute;
-        width: 100%;
-        z-index: 1;
-      }
     }
   }
 }
@@ -46,9 +21,5 @@
 }
 
 .feature-image {
-  width: 75px;
-}
-
-.feature-item > a > .feature-title {
-  font-size: 1.1em;
+  width: 300px;
 }

--- a/src/htdocs/features.php
+++ b/src/htdocs/features.php
@@ -27,8 +27,8 @@ $EQ_FEATURES->items[] = array(
   adipisicing elit, sed do eiusmod tempor incididunt ut labore.</p>',
   'link' => 'http://url.of.webpage/',
   'modified' => strtotime('2014-11-01'),
-  'thumbnail' => 'http://placehold.it/75x75',
-  'image' => 'http://placehold.it/464x300'
+  'thumbnail' => 'http://placehold.it/300x200',
+  'image' => 'http://placehold.it/600x400'
 );
 
 $EQ_FEATURES->items[] = array(
@@ -40,8 +40,8 @@ $EQ_FEATURES->items[] = array(
   commodo consequat.',
   'link' => 'http://url.of.webpage/',
   'modified' => strtotime('2014-11-01'),
-  'thumbnail' => 'http://placehold.it/75x75',
-  'image' => 'http://placehold.it/75x75'
+  'thumbnail' => 'http://placehold.it/300x200',
+  'image' => 'http://placehold.it/600x400'
 );
 
 $EQ_FEATURES->items[] = array(
@@ -53,8 +53,8 @@ $EQ_FEATURES->items[] = array(
   commodo consequat.',
   'link' => 'http://url.of.webpage/',
   'modified' => strtotime('2014-11-01'),
-  'thumbnail' => 'http://placehold.it/75x75',
-  'image' => 'http://placehold.it/75x75'
+  'thumbnail' => 'http://placehold.it/300x200',
+  'image' => 'http://placehold.it/600x400'
 );
 
   echo $EQ_FEATURES->toHtml();
@@ -107,8 +107,8 @@ top just below the &ldquo;template&rdquo; code. (If for some reason the Featured
           elit, sed do eiusmod tempor incididunt ut labore.&lt;/p&gt;&rsquo;,
       &lsquo;link&rsquo; =&gt; &lsquo;http://url.of.webpage/&rsquo;,
       &lsquo;modified&rsquo; =&gt; strtotime(&lsquo;2014-11-01&lsquo;),
-      &lsquo;thumbnail&rsquo; =&gt; &lsquo;http://placehold.it/75x75&rsquo;,
-      &lsquo;image&rsquo; =&gt; &lsquo;http://placehold.it/464x300&rsquo;
+      &lsquo;thumbnail&rsquo; =&gt; &lsquo;http://placehold.it/300x200&rsquo;,
+      &lsquo;image&rsquo; =&gt; &lsquo;http://placehold.it/600x400&rsquo;
     );
 
     $EQ_FEATURES-&gt;items[] = array(
@@ -120,8 +120,8 @@ top just below the &ldquo;template&rdquo; code. (If for some reason the Featured
       laboris nisi ut aliquip ex ea commodo consequat.&rsquo;,
       &lsquo;link&rsquo; =&gt; &lsquo;http://url.of.webpage/&rsquo;,
       &lsquo;modified&rsquo; =&gt; strtotime(&lsquo;2014-11-01&rsquo;),
-      &lsquo;thumbnail&rsquo; =&gt; &lsquo;http://placehold.it/75x75&rsquo;,
-      &lsquo;image&rsquo; =&gt; &lsquo;http://placehold.it/75x75&rsquo;
+      &lsquo;thumbnail&rsquo; =&gt; &lsquo;http://placehold.it/300x200&rsquo;,
+      &lsquo;image&rsquo; =&gt; &lsquo;http://placehold.it/600x400&rsquo;
     );
 
     $EQ_FEATURES-&gt;items[] = array(
@@ -133,8 +133,8 @@ top just below the &ldquo;template&rdquo; code. (If for some reason the Featured
       laboris nisi ut aliquip ex ea commodo consequat.&rsquo;,
       &lsquo;link&rsquo; =&gt; &lsquo;http://url.of.webpage/&rsquo;,
       &lsquo;modified&rsquo; =&gt; strtotime(&lsquo;2014-11-01&rsquo;),
-      &lsquo;thumbnail&rsquo; =&gt; &lsquo;http://placehold.it/75x75&rsquo;,
-      &lsquo;image&rsquo; =&gt; &lsquo;http://placehold.it/75x75&rsquo;
+      &lsquo;thumbnail&rsquo; =&gt; &lsquo;http://placehold.it/300x200&rsquo;,
+      &lsquo;image&rsquo; =&gt; &lsquo;http://placehold.it/7600x400&rsquo;
     );
 
       echo $EQ_FEATURES-&gt;toHtml();

--- a/src/lib/Features.class.php
+++ b/src/lib/Features.class.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * A list of featured content.
  *
@@ -37,7 +36,6 @@
  *               strtotime('2014-10-31')
  */
 class Features {
-
   // id for features list.
   public $id = 'usgs_earthquake_home';
   // author for features list.
@@ -103,29 +101,40 @@ class Features {
    *        number of items to "feature".
    * @return {String} html.
    */
-  public function toHtml($numItems = 4, $numFeatured = 1) {
+  public function toHtml() {
     $items = $this->getItems();
     $len = count($items);
 
     $r = '';
     $r .= '<div class="row">';
 
-    for ($i = 0; $i < $len && $i < $numFeatured; $i++) {
       $r .= '<div class="column one-of-two feature-main">' .
-              $this->getFeaturedHtml($items[$i]) .
+              $this->getFeaturedHtml($items[0]) .
             '</div>';
-    }
 
-    $r .= '<div class="column one-of-two">';
-    $r .= '<ul class="no-style linklist feature-subfeatures">';
-    for ($i = $numFeatured; $i < $len && $i < $numItems; $i++) {
-      $r .= '<li class="feature-item">' .
-        $this->getItemHtml($items[$i]) .
-        '</li>';
-    }
-    $r .= '</ul>' .
-        '</div>' .
-      '</div>';
+      $r .= '<div class="column one-of-two">';
+        $r .= '<div class="row">';
+
+          $r .= '<div class="column one-of-two">';
+            $r .= '<ul class="no-style feature-subfeatures">';
+              $r .= '<li class="feature-item">' .
+                      $this->getItemHtml($items[1]) .
+                    '</li>' .
+                  '</ul>' .
+                '</div>';
+
+          $r .= '<div class="column one-of-two">';
+            $r .= '<ul class="no-style feature-subfeatures">';
+              $r .= '<li class="feature-item">' .
+                      $this->getItemHtml($items[2]) .
+                    '</li>' .
+                  '</ul>' .
+                '</div>';
+
+      $r .= '</div>' .
+          '</div>' .
+        '</div>';
+
     return $r;
   }
   /**
@@ -173,10 +182,10 @@ class Features {
    protected function getFeaturedHtml ($item) {
      return '' .
       '<a href="' . $item['link'] . '">' .
-        '<h3 class="feature-title">' . $item['title'] . '</h3>' .
         '<div class="feature-image" ' .
             'style="background-image:url(' . $item['image'] . ')"' .
             '></div>' .
+            '<h3 class="feature-title">' . $item['title'] . '</h3>' .
       '</a>' .
       '<p>' . $item['content'] . '</p>';
    }
@@ -189,9 +198,9 @@ class Features {
    protected function getItemHtml ($item) {
      return '' .
       '<a href="' . $item['link'] . '">' .
-        '<h3 class="feature-title">' . $item['title'] . '</h3>' .
         '<img class="feature-image" src="' . $item['thumbnail'] .
         '" alt="" />' .
+        '<h3 class="feature-title">' . $item['title'] . '</h3>' .
       '</a>' .
       '<p>' . $item['content'] . '</p>';
    }

--- a/src/lib/Features.class.php
+++ b/src/lib/Features.class.php
@@ -182,10 +182,10 @@ class Features {
    protected function getFeaturedHtml ($item) {
      return '' .
       '<a href="' . $item['link'] . '">' .
+        '<h3 class="feature-title">' . $item['title'] . '</h3>' .
         '<div class="feature-image" ' .
             'style="background-image:url(' . $item['image'] . ')"' .
-            '></div>' .
-            '<h3 class="feature-title">' . $item['title'] . '</h3>' .
+      '></div>' .
       '</a>' .
       '<p>' . $item['content'] . '</p>';
    }
@@ -198,9 +198,9 @@ class Features {
    protected function getItemHtml ($item) {
      return '' .
       '<a href="' . $item['link'] . '">' .
+        '<h3 class="feature-title">' . $item['title'] . '</h3>' .
         '<img class="feature-image" src="' . $item['thumbnail'] .
         '" alt="" />' .
-        '<h3 class="feature-title">' . $item['title'] . '</h3>' .
       '</a>' .
       '<p>' . $item['content'] . '</p>';
    }


### PR DESCRIPTION
The previous layout didn't match the layout of the section pages or the homepage.  Now it's a 2-column 50/50 layout that matches the homepage.  I'm thinking any highlight will be on the homepage, and a section thing will be an announcement using class 'alert'.

So the Research section page in the future will not have 3 featured items.