### PR TITLE
allow user to set <title> independently from <h1>

### DIFF
--- a/src/lib/config.inc.php
+++ b/src/lib/config.inc.php
@@ -13,6 +13,11 @@ if (!isset($TITLE)) {
 	$TITLE = 'Default Page Title';
 }
 
+// allow user to set <title> independently of <h1>; use $TITLE by default
+if (!isset($TITLETAG)) {
+  $TITLETAG = $TITLE;
+}
+
 // page contact, email address
 if (!isset($CONTACT)) {
 	$CONTACT = null;

--- a/src/lib/layout.inc.php
+++ b/src/lib/layout.inc.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><?php echo strip_tags($TITLE); ?></title>
+  <title><?php echo strip_tags($TITLETAG); ?></title>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <?php


### PR DESCRIPTION
Sometimes it's desirable to set &lt;title&gt; to a different value than &lt;h1&gt;. The specific use case I have is that I want to give multiple "sibling" pages w/ the same &lt;h1&gt; tag (but different subtitles) a unique &lt;title&gt; tag to assist the user navigating their history within an app.

It works as expected if you just include a $TITLE var (both &lt;title&gt; and &lt;h1&gt; are set to $TITLE), but if you also include a $TITLETAG var, this value will override $TITLE for &lt;title&gt;.