### PR TITLE
Update css background images to use relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Follow these steps to wrap your application in the hazdev angular template.
     ```
     {
       "glob": "**/*",
-      "input": "../node_modules/hazdev-template/src/assets",
+      "input": "../node_modules/hazdev-ng-template/src/assets",
       "output": "./assets/"
     },
     ```

--- a/angular.json
+++ b/angular.json
@@ -19,13 +19,8 @@
             "assets": [
               {
                 "glob": "**/*",
-                "input": "../node_modules/hazdev-ng-template/assets",
-                "output": "./assets/"
-              },
-              {
-                "glob": "**/*",
-                "input": "dist/hazdev-ng-template/assets",
-                "output": "./assets/"
+                "input": "../projects/hazdev-ng-template/src/assets",
+                "output": "./assets"
               },
               "src/favicon.ico"
             ],
@@ -81,15 +76,9 @@
             "assets": [
               {
                 "glob": "**/*",
-                "input": "src/app/hazdev-template/header/assets",
-                "output": "/assets"
+                "input": "../projects/hazdev-ng-template/src/assets",
+                "output": "./assets"
               },
-              {
-                "glob": "**/*",
-                "input": "src/app/hazdev-template/page/assets",
-                "output": "/assets"
-              },
-              "src/assets",
               "src/favicon.ico"
             ]
           }
@@ -147,7 +136,15 @@
           "options": {
             "main": "projects/hazdev-ng-template/src/test.ts",
             "tsConfig": "projects/hazdev-ng-template/tsconfig.spec.json",
-            "karmaConfig": "projects/hazdev-ng-template/karma.conf.js"
+            "karmaConfig": "projects/hazdev-ng-template/karma.conf.js",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "projects/hazdev-ng-template/src/assets",
+                "output": "./assets"
+              },
+              "projects/hazdev-ng-template/src/favicon.ico"
+            ]
           }
         },
         "lint": {

--- a/projects/hazdev-ng-template/src/lib/page/page.component.scss
+++ b/projects/hazdev-ng-template/src/lib/page/page.component.scss
@@ -38,7 +38,7 @@ main {
 
 @media screen and (max-width: 767px) {
   .page-social > a {
-    background: url("/assets/social-sprite.png") no-repeat;
+    background: url("../../assets/social-sprite.png") no-repeat;
     content: " ";
     display: inline-block;
     height: 32px;
@@ -77,7 +77,7 @@ main {
 
     .page-social > a {
       &:before {
-        background: url("/assets/social-sprite.png") no-repeat;
+        background: url("../../assets/social-sprite.png") no-repeat;
         content: "";
         display: inline-block;
         height: 16px;

--- a/projects/hazdev-ng-template/src/lib/theme.scss
+++ b/projects/hazdev-ng-template/src/lib/theme.scss
@@ -75,4 +75,4 @@ $earthquake-header-background: #000000;
 
 /* Banner image */
 /* TODO, get a new banner image or remove entirely */
-$earthquake-header-banner-img: url("/assets/earthquake/banner.png");
+$earthquake-header-banner-img: url("../../assets/earthquake/banner.png");


### PR DESCRIPTION
Fixes usgs/earthquake-eventpages#1328

Ran ./build.sh from root, then installed in earthquake-eventpages, and appeared to work as expected.

- Paths to assets need to be relative to css file where rule is used
- For theme.scss, it's defining a variable that is used in header; maybe this should be changed.
- Added assets to test configuration in angular.json to make tests pass.